### PR TITLE
Loosen preconditions on serializePathv2

### DIFF
--- a/src/helperV2.js
+++ b/src/helperV2.js
@@ -7,9 +7,15 @@ export function serializePathv2(path) {
   }
 
   const buf = Buffer.alloc(20);
-  buf.writeUInt32LE(0x80000000 + path[0], 0);
-  buf.writeUInt32LE(0x80000000 + path[1], 4);
-  buf.writeUInt32LE(0x80000000 + path[2], 8);
+  // HACK : without the >>>,
+  // the bitwise implicitly casts the result to be a signed int32,
+  // which fails the internal type check of Buffer in case of overload.
+  // eslint-disable-next-line no-bitwise
+  buf.writeUInt32LE((0x80000000 | path[0]) >>> 0, 0);
+  // eslint-disable-next-line no-bitwise
+  buf.writeUInt32LE((0x80000000 | path[1]) >>> 0, 4);
+  // eslint-disable-next-line no-bitwise
+  buf.writeUInt32LE((0x80000000 | path[2]) >>> 0, 8);
   buf.writeUInt32LE(path[3], 12);
   buf.writeUInt32LE(path[4], 16);
 


### PR DESCRIPTION
This change allows callers of `serializePathv2` to provide already hardened values in the `path` argument.