### PR TITLE
Remove crypto from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@zondax/ledger-js": "^0.10.0",
     "bech32": "^2.0.0",
     "buffer": "^6.0.3",
-    "crypto": "^1.0.1",
     "crypto-browserify": "^3.12.0",
     "ripemd160": "^2.0.2",
     "stream-browserify": "^3.0.0"


### PR DESCRIPTION
Hello,

We had an issue on Ledger Live where declaring crypto as a dependency prevented Metro from resolving the polyfill and it tried to resolve this deprecated package instead.
See: https://github.com/LedgerHQ/ledger-live/pull/7293

I had to explicitly remove the crypto dependency to make it work.
As the package is deprecated and does not exist anymore I think that we should remove it from the list of dependencies.
Thanks a lot for your help!